### PR TITLE
feat: monthly, weekly report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -68,6 +83,20 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "compact_str"
@@ -501,6 +530,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +831,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1762,6 +1824,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2172,7 @@ dependencies = [
 name = "yomitore"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "crossterm",
  "dirs",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ unicode-segmentation = "1.10.0"
 unicode-width = "0.1"
 ratatui = { version = "0.29.0", features = ["crossterm"] }
 crossterm = { version = "0.28.1", features = ["event-stream"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,12 @@
 use crate::api_client::ApiClient;
+use crate::stats::TrainingStats;
+
+#[derive(PartialEq, Clone, Copy)]
+pub enum ViewMode {
+    Normal,
+    MonthlyReport,
+    WeeklyReport,
+}
 
 /// Application state
 pub struct App {
@@ -15,10 +23,13 @@ pub struct App {
     pub cursor_position: usize,
     pub is_evaluating: bool,
     pub show_evaluation: bool,
+    pub view_mode: ViewMode,
+    pub stats: TrainingStats,
 }
 
 impl Default for App {
     fn default() -> Self {
+        let stats = TrainingStats::load().unwrap_or_else(|_| TrainingStats::new());
         Self {
             api_client: None,
             is_editing: false,
@@ -33,6 +44,8 @@ impl Default for App {
             cursor_position: 0,
             is_evaluating: false,
             show_evaluation: false,
+            view_mode: ViewMode::Normal,
+            stats,
         }
     }
 }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -1,0 +1,216 @@
+use crate::stats::{DailyStats, TrainingStats, WeeklyStats};
+use chrono::{Datelike, Local, NaiveDate};
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Paragraph},
+};
+use std::collections::HashMap;
+
+const DAYS_IN_MONTH: usize = 30;
+const WEEKS_TO_SHOW: usize = 4;
+
+pub fn render_monthly_report(frame: &mut Frame, area: Rect, stats: &TrainingStats) {
+    let daily_stats = stats.get_daily_stats(DAYS_IN_MONTH);
+
+    let block = Block::default()
+        .title("月次レポート (m: 閉じる)")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Create heatmap
+    let heatmap = create_heatmap(&daily_stats, inner.width as usize, inner.height as usize);
+    let paragraph = Paragraph::new(heatmap);
+    frame.render_widget(paragraph, inner);
+}
+
+pub fn render_weekly_report(frame: &mut Frame, area: Rect, stats: &TrainingStats) {
+    let weekly_stats = stats.get_weekly_stats(WEEKS_TO_SHOW);
+
+    let block = Block::default()
+        .title("週次レポート (w: 閉じる)")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Magenta));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Create bar chart
+    let chart = create_bar_chart(&weekly_stats, inner.width as usize, inner.height as usize);
+    let paragraph = Paragraph::new(chart);
+    frame.render_widget(paragraph, inner);
+}
+
+fn create_heatmap(daily_stats: &HashMap<NaiveDate, DailyStats>, _width: usize, _height: usize) -> Text<'static> {
+    let mut lines = Vec::new();
+    let today = Local::now().date_naive();
+
+    // Title
+    lines.push(Line::from(vec![
+        Span::styled("過去30日間の成績", Style::default().bold()),
+    ]));
+    lines.push(Line::from(""));
+
+    // Calculate grid dimensions (7 columns for days of week, multiple rows for weeks)
+    let cols = 7;
+    let rows = (DAYS_IN_MONTH + 6) / 7; // Round up to include partial weeks
+
+    // Create week day labels
+    let weekdays = vec!["日", "月", "火", "水", "木", "金", "土"];
+    let mut header = vec![Span::raw("    ")];
+    for day in &weekdays {
+        header.push(Span::raw(format!(" {} ", day)));
+    }
+    lines.push(Line::from(header));
+
+    // Generate heatmap grid
+    for row in 0..rows {
+        let mut line_spans = Vec::new();
+
+        // Week label
+        let week_offset = rows - row - 1;
+        let date = today - chrono::Duration::days((week_offset * 7) as i64);
+        line_spans.push(Span::raw(format!("W{:02} ", date.iso_week().week())));
+
+        for col in 0..cols {
+            let days_ago = (week_offset * 7) + col;
+            if days_ago >= DAYS_IN_MONTH {
+                line_spans.push(Span::raw("   "));
+                continue;
+            }
+
+            let date = today - chrono::Duration::days(days_ago as i64);
+
+            if let Some(stats) = daily_stats.get(&date) {
+                let total = stats.total();
+                let correct = stats.correct;
+
+                // Determine color intensity based on correct answers
+                let (symbol, style) = match (total, correct) {
+                    (0, _) => ("□", Style::default().fg(Color::DarkGray)),
+                    (_, c) if c == 0 => ("■", Style::default().fg(Color::Red)),
+                    (t, c) if c == t => {
+                        // All correct - varying shades of green
+                        if t >= 5 {
+                            ("■", Style::default().fg(Color::Green).bold())
+                        } else if t >= 3 {
+                            ("■", Style::default().fg(Color::Green))
+                        } else {
+                            ("■", Style::default().fg(Color::LightGreen))
+                        }
+                    }
+                    (t, c) => {
+                        // Mixed results
+                        let ratio = c as f64 / t as f64;
+                        if ratio >= 0.7 {
+                            ("■", Style::default().fg(Color::LightGreen))
+                        } else if ratio >= 0.4 {
+                            ("■", Style::default().fg(Color::Yellow))
+                        } else {
+                            ("■", Style::default().fg(Color::Red))
+                        }
+                    }
+                };
+
+                line_spans.push(Span::styled(format!(" {} ", symbol), style));
+            } else {
+                line_spans.push(Span::raw(" □ "));
+            }
+        }
+
+        lines.push(Line::from(line_spans));
+    }
+
+    // Legend
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::raw("凡例: "),
+        Span::styled("□", Style::default().fg(Color::DarkGray)),
+        Span::raw(" なし  "),
+        Span::styled("■", Style::default().fg(Color::Red)),
+        Span::raw(" 全不正解  "),
+        Span::styled("■", Style::default().fg(Color::Yellow)),
+        Span::raw(" 混在  "),
+        Span::styled("■", Style::default().fg(Color::LightGreen)),
+        Span::raw(" 良  "),
+        Span::styled("■", Style::default().fg(Color::Green)),
+        Span::raw(" 優  "),
+        Span::styled("■", Style::default().fg(Color::Green).bold()),
+        Span::raw(" 秀"),
+    ]));
+
+    Text::from(lines)
+}
+
+fn create_bar_chart(weekly_stats: &[WeeklyStats], _width: usize, height: usize) -> Text<'static> {
+    let mut lines = Vec::new();
+
+    // Title
+    lines.push(Line::from(vec![
+        Span::styled("過去4週間の成績", Style::default().bold()),
+    ]));
+    lines.push(Line::from(""));
+
+    // Find max value for scaling
+    let max_value = weekly_stats
+        .iter()
+        .map(|s| s.correct.max(s.incorrect))
+        .max()
+        .unwrap_or(1);
+
+    let chart_height = (height.saturating_sub(6)).max(8);
+
+    // Display each week
+    for stats in weekly_stats {
+        let correct_bars = if max_value > 0 {
+            (stats.correct as f64 / max_value as f64 * chart_height as f64) as usize
+        } else {
+            0
+        };
+
+        let incorrect_bars = if max_value > 0 {
+            (stats.incorrect as f64 / max_value as f64 * chart_height as f64) as usize
+        } else {
+            0
+        };
+
+        let mut line_spans = vec![
+            Span::raw(format!("第{}週: ", stats.week_number)),
+        ];
+
+        // Correct bar (green)
+        line_spans.push(Span::styled(
+            "█".repeat(correct_bars),
+            Style::default().fg(Color::Green),
+        ));
+        line_spans.push(Span::raw(format!(" {}", stats.correct)));
+
+        lines.push(Line::from(line_spans));
+
+        // Incorrect bar (red)
+        let mut incorrect_line = vec![
+            Span::raw("       "),
+        ];
+        incorrect_line.push(Span::styled(
+            "█".repeat(incorrect_bars),
+            Style::default().fg(Color::Red),
+        ));
+        incorrect_line.push(Span::raw(format!(" {}", stats.incorrect)));
+
+        lines.push(Line::from(incorrect_line));
+        lines.push(Line::from(""));
+    }
+
+    // Legend
+    lines.push(Line::from(vec![
+        Span::raw("凡例: "),
+        Span::styled("█", Style::default().fg(Color::Green)),
+        Span::raw(" 正解  "),
+        Span::styled("█", Style::default().fg(Color::Red)),
+        Span::raw(" 不正解"),
+    ]));
+
+    Text::from(lines)
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,137 @@
+use chrono::{DateTime, Local, NaiveDate};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TrainingResult {
+    pub timestamp: DateTime<Local>,
+    pub passed: bool,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct TrainingStats {
+    pub results: Vec<TrainingResult>,
+}
+
+impl TrainingStats {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn load() -> Result<Self, Box<dyn std::error::Error>> {
+        let path = Self::get_stats_file_path()?;
+        if !path.exists() {
+            return Ok(Self::new());
+        }
+        let content = fs::read_to_string(&path)?;
+        let stats: TrainingStats = serde_json::from_str(&content)?;
+        Ok(stats)
+    }
+
+    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let path = Self::get_stats_file_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = serde_json::to_string_pretty(self)?;
+        fs::write(&path, content)?;
+        Ok(())
+    }
+
+    pub fn add_result(&mut self, passed: bool) {
+        self.results.push(TrainingResult {
+            timestamp: Local::now(),
+            passed,
+        });
+    }
+
+    fn get_stats_file_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let home = dirs::home_dir().ok_or("Could not find home directory")?;
+        Ok(home.join(".config").join("yomitore").join("stats.json"))
+    }
+
+    /// Get daily aggregated stats for the last N days
+    pub fn get_daily_stats(&self, days: usize) -> HashMap<NaiveDate, DailyStats> {
+        let mut daily_map: HashMap<NaiveDate, DailyStats> = HashMap::new();
+        let today = Local::now().date_naive();
+
+        // Initialize all dates with empty stats
+        for i in 0..days {
+            let date = today - chrono::Duration::days(i as i64);
+            daily_map.insert(date, DailyStats::default());
+        }
+
+        // Aggregate results
+        for result in &self.results {
+            let date = result.timestamp.date_naive();
+            if let Some(stats) = daily_map.get_mut(&date) {
+                if result.passed {
+                    stats.correct += 1;
+                } else {
+                    stats.incorrect += 1;
+                }
+            }
+        }
+
+        daily_map
+    }
+
+    /// Get weekly stats for the last N weeks
+    pub fn get_weekly_stats(&self, weeks: usize) -> Vec<WeeklyStats> {
+        let mut weekly_stats = Vec::new();
+        let now = Local::now();
+
+        for week in 0..weeks {
+            let week_start = now - chrono::Duration::weeks((weeks - week - 1) as i64);
+            let week_end = week_start + chrono::Duration::weeks(1);
+
+            let mut correct = 0;
+            let mut incorrect = 0;
+
+            for result in &self.results {
+                if result.timestamp >= week_start && result.timestamp < week_end {
+                    if result.passed {
+                        correct += 1;
+                    } else {
+                        incorrect += 1;
+                    }
+                }
+            }
+
+            weekly_stats.push(WeeklyStats {
+                week_number: week + 1,
+                correct,
+                incorrect,
+            });
+        }
+
+        weekly_stats
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct DailyStats {
+    pub correct: usize,
+    pub incorrect: usize,
+}
+
+impl DailyStats {
+    pub fn total(&self) -> usize {
+        self.correct + self.incorrect
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WeeklyStats {
+    pub week_number: usize,
+    pub correct: usize,
+    pub incorrect: usize,
+}
+
+impl WeeklyStats {
+    pub fn total(&self) -> usize {
+        self.correct + self.incorrect
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,5 @@
-use crate::app::App;
+use crate::app::{App, ViewMode};
+use crate::reports;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Paragraph, Wrap},
@@ -6,6 +7,20 @@ use ratatui::{
 
 /// Renders the user interface widgets.
 pub fn render(app: &mut App, frame: &mut Frame) {
+    // Check if we should show a report instead of the normal view
+    match app.view_mode {
+        ViewMode::MonthlyReport => {
+            render_monthly_report_view(app, frame);
+            return;
+        }
+        ViewMode::WeeklyReport => {
+            render_weekly_report_view(app, frame);
+            return;
+        }
+        ViewMode::Normal => {
+            // Continue with normal rendering
+        }
+    }
     let main_layout = if app.show_evaluation {
         Layout::default()
             .direction(Direction::Vertical)
@@ -125,9 +140,39 @@ fn render_evaluation(app: &App, frame: &mut Frame, area: Rect) {
 
 fn render_status_bar(app: &App, frame: &mut Frame, area: Rect) {
     let block = Block::default().borders(Borders::TOP);
-    let status_text = format!(" {} | q: 終了 ", app.status_message);
+    let status_text = format!(" {} | m: 月次 | w: 週次 | q: 終了 ", app.status_message);
     let paragraph = Paragraph::new(status_text)
         .alignment(Alignment::Right)
         .block(block);
     frame.render_widget(paragraph, area);
+}
+
+fn render_monthly_report_view(app: &App, frame: &mut Frame) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),      // Header
+            Constraint::Min(0),         // Report
+            Constraint::Length(3),      // Status
+        ])
+        .split(frame.area());
+
+    render_header(frame, layout[0]);
+    reports::render_monthly_report(frame, layout[1], &app.stats);
+    render_status_bar(app, frame, layout[2]);
+}
+
+fn render_weekly_report_view(app: &App, frame: &mut Frame) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),      // Header
+            Constraint::Min(0),         // Report
+            Constraint::Length(3),      // Status
+        ])
+        .split(frame.area());
+
+    render_header(frame, layout[0]);
+    reports::render_weekly_report(frame, layout[1], &app.stats);
+    render_status_bar(app, frame, layout[2]);
 }


### PR DESCRIPTION
## 実装内容

1. データ構造と永続化 (src/stats.rs)

- TrainingResult: タイムスタンプと正誤を記録
- TrainingStats: 結果のリストを管理し、JSON形式で `~/.config/yomitore/stats.json` に保存
- DailyStats: 日別の正解数・不正解数を集計
- WeeklyStats: 週別の正解数・不正解数を集計

2. 月次レポート (GitHub スタイルのヒートマップ)

- 過去30日間の成績を7列（曜日）× 複数行（週）のグリッドで表示
- 色の濃淡:
  - □ (灰色): データなし
  - ■ (赤): 全不正解
  - ■ (黄色): 混在（正解率40-70%）
  - ■ (薄緑): 良（正解率70%以上 or 全正解で少数）
  - ■ (緑): 優（全正解で3-4回）
  - ■ (濃緑・太字): 秀（全正解で5回以上）
- キーボード: m で表示/非表示切替

3. 週次レポート (棒グラフ)

- 過去4週間の成績を表示
- 各週ごとに:
  - 緑の棒: 正解数
  - 赤の棒: 不正解数
- キーボード: w で表示/非表示切替

4. 統合機能

- 自動保存: 評価完了後に結果を自動保存 (src/main.rs:64-67)
- 起動時読込: アプリ起動時に過去の成績を読み込み (src/app.rs:32)
- キーボードショートカット:
  - m: 月次レポート表示/非表示
  - w: 週次レポート表示/非表示
- ステータスバー更新: レポートの操作方法を表示 (src/ui.rs:143)

## 使い方

1. トレーニングを行い、評価を受けると自動的に成績が記録されます
2. m キーを押すと月次レポート（GitHub スタイルのヒートマップ）が表示されます
3. w キーを押すと週次レポート（棒グラフ）が表示されます
4. 再度同じキーを押すと通常画面に戻ります

データは `~/.config/yomitore/stats.json` に保存され、アプリを再起動しても過去の成績が保持されます。