### PR TITLE
ref: ref

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,9 @@ pub enum ViewMode {
     WeeklyReport,
 }
 
+/// Menu options for character count selection
+pub const MENU_OPTIONS: [u16; 4] = [400, 720, 1440, 2880];
+
 /// Application state
 pub struct App {
     pub api_client: Option<ApiClient>,
@@ -51,6 +54,32 @@ impl Default for App {
             stats,
             character_count: 400,
             selected_menu_item: 0,
+        }
+    }
+}
+
+impl App {
+    /// Generate the text generation prompt based on current character count
+    pub fn generate_text_prompt(&self) -> String {
+        format!(
+            "日本語の公的文書のようなお堅い文章を{}文字程度で生成してください。",
+            self.character_count
+        )
+    }
+
+    /// Check if the current state indicates no training has started
+    pub fn has_training_started(&self) -> bool {
+        self.original_text != "Authenticating..." && !self.original_text.starts_with("Failed to generate")
+    }
+
+    /// Return to the appropriate view mode (Menu if no training, Normal otherwise)
+    pub fn return_from_report(&mut self) {
+        if self.has_training_started() {
+            self.view_mode = ViewMode::Normal;
+            self.status_message = "Normal Mode. Press 'i' to edit.".to_string();
+        } else {
+            self.view_mode = ViewMode::Menu;
+            self.status_message = "Select character count and press Enter to start".to_string();
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub fn save_api_key(api_key: &str) -> Result<(), AppError> {
         api_key: Some(api_key.to_string()),
     };
     let toml_string = toml::to_string(&config)
-        .map_err(|_| AppError::IoError(std::io::Error::new(std::io::ErrorKind::Other, "Failed to serialize config")))?;
+        .map_err(|_| AppError::IoError(std::io::Error::other("Failed to serialize config")))?;
 
     let mut file = OpenOptions::new().write(true).create(true).truncate(true).open(&config_path)?;
     
@@ -56,7 +56,7 @@ pub fn load_api_key() -> Result<Option<String>, AppError> {
     file.read_to_string(&mut contents)?;
 
     let config: Config = toml::from_str(&contents)
-        .map_err(|_| AppError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, "Failed to parse config")))?;
+        .map_err(|_| AppError::IoError(std::io::Error::other("Failed to parse config")))?;
     
     Ok(config.api_key)
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -74,7 +74,7 @@ impl TrainingStats {
             self.current_streak += 1;
 
             // Award consecutive streak badge (every 5, max 10 badges = 50 streak)
-            if self.current_streak % 5 == 0 && self.current_streak <= 50 {
+            if self.current_streak.is_multiple_of(5) && self.current_streak <= 50 {
                 let badge = Badge {
                     badge_type: BadgeType::ConsecutiveStreak(self.current_streak),
                     earned_at: Local::now(),
@@ -89,7 +89,7 @@ impl TrainingStats {
             let total_correct = self.results.iter().filter(|r| r.passed).count();
 
             // Award cumulative milestone badge (every 5, max 20 badges = 100 total)
-            if total_correct % 5 == 0 && total_correct <= 100 {
+            if total_correct.is_multiple_of(5) && total_correct <= 100 {
                 let badge = Badge {
                     badge_type: BadgeType::CumulativeMilestone(total_correct),
                     earned_at: Local::now(),
@@ -126,9 +126,9 @@ impl TrainingStats {
     /// Rebuild badges from historical data
     fn rebuild_badges_from_history(&mut self) {
         // Track all streak milestones and cumulative milestones reached
-        let mut max_streak = 0;
-        let mut current_streak = 0;
-        let mut total_correct = 0;
+        let mut max_streak: usize = 0;
+        let mut current_streak: usize = 0;
+        let mut total_correct: usize = 0;
 
         for result in &self.results {
             if result.passed {
@@ -137,7 +137,7 @@ impl TrainingStats {
                 max_streak = max_streak.max(current_streak);
 
                 // Award consecutive streak badges
-                if current_streak % 5 == 0 && current_streak <= 50 {
+                if current_streak.is_multiple_of(5) && current_streak <= 50 {
                     let badge = Badge {
                         badge_type: BadgeType::ConsecutiveStreak(current_streak),
                         earned_at: result.timestamp,
@@ -148,7 +148,7 @@ impl TrainingStats {
                 }
 
                 // Award cumulative milestone badges
-                if total_correct % 5 == 0 && total_correct <= 100 {
+                if total_correct.is_multiple_of(5) && total_correct <= 100 {
                     let badge = Badge {
                         badge_type: BadgeType::CumulativeMilestone(total_correct),
                         earned_at: result.timestamp,
@@ -219,14 +219,6 @@ impl TrainingStats {
         }
 
         weekly_stats
-    }
-
-    /// Get badges sorted by earned time
-    #[allow(dead_code)]
-    pub fn get_badges(&self) -> Vec<&Badge> {
-        let mut badges: Vec<&Badge> = self.badges.iter().collect();
-        badges.sort_by(|a, b| b.earned_at.cmp(&a.earned_at));
-        badges
     }
 
     /// Get badges grouped by type for display

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -17,8 +17,7 @@ pub fn init() -> io::Result<Tui> {
     // Check terminal size before initialization
     let (width, height) = size()?;
     if width < MIN_WIDTH || height < MIN_HEIGHT {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
+        return Err(io::Error::other(
             format!(
                 "Terminal size too small. Required: {}x{}, Current: {}x{}\nPlease resize your terminal and try again.",
                 MIN_WIDTH, MIN_HEIGHT, width, height

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, ViewMode};
+use crate::app::{App, ViewMode, MENU_OPTIONS};
 use crate::reports;
 use ratatui::{
     prelude::*,
@@ -234,11 +234,10 @@ fn render_menu_view(app: &App, frame: &mut Frame) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan));
 
-    let menu_options = vec![400, 720, 1440, 2880];
     let mut menu_text = String::new();
     menu_text.push_str("\n\n");
 
-    for (i, &count) in menu_options.iter().enumerate() {
+    for (i, &count) in MENU_OPTIONS.iter().enumerate() {
         if i == app.selected_menu_item {
             menu_text.push_str(&format!("  > {} 文字 <\n\n", count));
         } else {


### PR DESCRIPTION
  コードレビュー完了報告 ✅

  すべての問題点を修正しました。以下が実施した内容です。

  🔴 重複ロジックの修正

  1. メニューオプションの統合 (app.rs:13)
    - vec![400, 720, 1440, 2880] の重複定義を MENU_OPTIONS 定数に統合
    - main.rs、ui.rs で使用
  2. テキスト生成プロンプトの関数化 (app.rs:62-68)
    - 重複していたプロンプト文字列を generate_text_prompt() メソッドに抽出
    - main.rs:35, 89で使用
  3. API呼び出しの共通化 (api_client.rs:69-102)
    - send_chat_request() プライベートヘルパーメソッドを作成
    - generate_text() と evaluate_summary() で再利用
  4. バッジ表示ロジックの統合 (reports.rs:12-44)
    - render_badge_section() 関数を作成
    - 月次・週次レポートで共通利用
  5. ビューモード復帰ロジックの統合 (app.rs:75-84)
    - return_from_report() メソッドを作成
    - main.rs:233, 242で使用

  🟡 Clippyの警告修正

  6. std::io::Error::other() の使用 (config.rs:27, 59, tui.rs:20)
  7. div_ceil() メソッドの使用 (reports.rs:95, 115)
  8. 冗長なガード条件の削除 (reports.rs:141)
  9. is_multiple_of() の使用 (stats.rs:77, 92, 140, 151)
  10. ネストされたif文の統合 (main.rs:116-118, 277-283, 285-294)

  🔵 未使用コードの削除

  11. 未使用メソッドの削除 (stats.rs:224-229)
    - get_badges() メソッドを削除（get_badges_by_type() で十分）

  ✅ 検証結果

  - ✅ cargo build - ビルド成功
  - ✅ cargo clippy - 警告0件
  - ✅ cargo test - 全テスト合格 (3/3)
